### PR TITLE
Enable view transitions with page fade animation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ViewTransition } from "react";
 import Script from "next/script";
 import { daily as dailyTheme } from "@grantcodes/themer";
 
@@ -130,7 +131,9 @@ export default function RootLayout({
 				{/* Script to load theme without flash */}
 				<Script strategy="beforeInteractive" src="/load-theme.js" />
 			</head>
-			<body>{children}</body>
+			<body>
+					<ViewTransition>{children}</ViewTransition>
+				</body>
 		</html>
 	);
 }

--- a/css/base/index.scss
+++ b/css/base/index.scss
@@ -54,3 +54,32 @@
 @import './layout/nav';
 @import './layout/footer';
 @import './print';
+
+// View Transitions
+::view-transition-old(root) {
+  animation: view-fade-out 0.2s ease;
+}
+
+::view-transition-new(root) {
+  animation: view-fade-in 0.2s ease;
+}
+
+@keyframes view-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes view-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ const subdomains = [
 ];
 
 const config = {
+	experimental: {
+		viewTransition: true,
+	},
 	serverExternalPackages: ["canvas"],
 	turbopack: {
 		rules: {


### PR DESCRIPTION
## Summary
- Enable the View Transitions API via `experimental.viewTransition` in next.config.js
- Wrap root layout children in React 19's `<ViewTransition>` component for automatic page fade transitions
- Add 0.2s ease fade animation CSS targeting `::view-transition-old/new(root)`
- Respect `prefers-reduced-motion: reduce` by disabling all view transition animations

## How it works
- Navigating between pages triggers a cross-fade (old page fades out, new page fades in)
- Browser back/forward also triggers the animation automatically
- Browsers without View Transitions API support (Firefox, older browsers) work exactly as before — no errors, no broken layout
- Users with reduced motion preference see instant page swaps with no animation

## Files changed
- `next.config.js` — added `experimental.viewTransition: true`
- `app/layout.tsx` — imported and wrapped children with `<ViewTransition>` from React 19
- `css/base/index.scss` — fade keyframes + reduced motion override