### PR TITLE
fix: month archive 500 errors + reduce revalidate to 30min

### DIFF
--- a/app/(default)/[typeOrYear]/[month]/[day]/[slug]/page.tsx
+++ b/app/(default)/[typeOrYear]/[month]/[day]/[slug]/page.tsx
@@ -18,8 +18,10 @@ export async function generateStaticParams () {
   const posts = await getPosts({ limit: 25 })
 
   // Helper function to add 0 to the start of numbers
-  const leadingZero = num =>
-    parseInt(num) < 10 && parseInt(num) > 0 ? `0${num}` : `${num}`
+  const leadingZero = num => {
+    const n = parseInt(num)
+    return n < 10 && n > 0 ? `0${n}` : `${n}`
+  }
 
   // Get the url params for each
   const params = posts.map(post => {

--- a/app/(default)/[typeOrYear]/[month]/page.tsx
+++ b/app/(default)/[typeOrYear]/[month]/page.tsx
@@ -1,9 +1,12 @@
+import { notFound } from "next/navigation";
 import { DataSummary } from "components/DataSummary";
 import getMonthData from "lib/get/month-data";
 import getMonthDataFiles from "lib/get/month-data-files";
 
-const leadingZero = (num) =>
-	parseInt(num) < 10 && parseInt(num) > 0 ? `0${num}` : `${num}`;
+const leadingZero = (num) => {
+	const n = parseInt(num);
+	return n < 10 && n > 0 ? `0${n}` : `${n}`;
+};
 
 // TODO: Improve data fetching
 const MonthlySummary = async (props) => {
@@ -14,12 +17,12 @@ const MonthlySummary = async (props) => {
 		!parseInt(params.typeOrYear) ||
 		!parseInt(params.month)
 	) {
-		throw new Error("Year or month is not defined");
+		notFound();
 	}
 
 	const data = getMonthData(params.typeOrYear, params.month);
 	if (!data) {
-		throw new Error("No data returned");
+		notFound();
 	}
 
 	const { typeOrYear: year, month } = params;
@@ -30,7 +33,7 @@ const MonthlySummary = async (props) => {
 		monthInt === 12 ? "01" : leadingZero(monthInt + 1)
 	}`;
 	const previousLink = `/${monthInt === 1 ? yearInt - 1 : year}/${
-		month === 1 ? 12 : leadingZero(monthInt - 1)
+		monthInt === 1 ? 12 : leadingZero(monthInt - 1)
 	}`;
 
 	return (

--- a/app/(default)/feeds/page.tsx
+++ b/app/(default)/feeds/page.tsx
@@ -76,7 +76,7 @@ const Feeds = async () => {
 
 export default Feeds
 
-export const revalidate = 43200
+export const revalidate = 1800
 
 export const metadata = {
   title: 'Feeds',

--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -6,7 +6,7 @@ const Home = async props => {
   const params = await props.params;
   const posts = await getPosts({ query: params })
 
-  if (!posts) {
+  if (!posts || !posts.length) {
     return <Profile vertical />
   }
 
@@ -17,6 +17,6 @@ export const metadata = {
   title: 'Home',
 }
 
-export const revalidate = 43200
+export const revalidate = 1800
 
 export default Home

--- a/app/(full-width)/photos/page.tsx
+++ b/app/(full-width)/photos/page.tsx
@@ -12,7 +12,7 @@ const Page = async props => {
 
 export default Page
 
-export const revalidate = 43200
+export const revalidate = 1800
 
 export const metadata = {
   title: 'Photos',

--- a/lib/get/posts.js
+++ b/lib/get/posts.js
@@ -20,7 +20,7 @@ const getPosts = async (ctx) => {
       body: JSON.stringify({ query, limit, showAll }),
       timeout: 15000,
       next: {
-        revalidate: 60 * 60 * 12,
+        revalidate: 60 * 30,
       },
     })
     const data = await res.json()


### PR DESCRIPTION
## Summary

Fixes the production 500 errors on the homepage and month archive routes, and reduces ISR revalidate time for faster recovery from backend issues.

## Changes

### Bug Fixes

- **Month archive 500 errors** — Invalid URLs like `/notes/05` or `/2017/0` were matching the `[typeOrYear]/[month]` route and throwing `Error: Year or month is not defined`, resulting in 500s. Replaced `throw` with `notFound()` so these return proper 404s.
- **`leadingZero` double-padding bug** — `leadingZero("05")` returned `"005"` because it prepended `0` without parsing to integer first. Fixed in both the month archive and day/slug pages.
- **January previous month link** — `month === 1` (string vs number) was always false, so January's previous link pointed to `/YYYY/0` instead of `/YYYY-1/12`. Fixed to `monthInt === 1`.
- **Homepage empty post list** — `getPosts()` always returns an array (`[]` on failure), so the `if (!posts)` fallback to `<Profile />` never triggered. Changed to `if (!posts || !posts.length)`.

### Revalidate Reduction

Reduced ISR revalidate from **12 hours → 30 minutes** across:
- `app/(default)/page.tsx`
- `app/(default)/feeds/page.tsx`
- `app/(full-width)/photos/page.tsx`
- `lib/get/posts.js` (fetch cache)

This helps the site recover faster when the backend is temporarily unavailable during builds.

## Testing

- TypeScript compiles cleanly
- Invalid month URLs now return 404 instead of 500
- Homepage falls back to Profile when backend returns no posts