### PR TITLE
fix: reduce deployment build fanout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 # app stuff
 backend/.data
 backend
+.planning
+.planning/

--- a/app/(default)/[typeOrYear]/page.tsx
+++ b/app/(default)/[typeOrYear]/page.tsx
@@ -1,6 +1,5 @@
 import PostList from "components/PostList";
 import { DataSummary } from "components/DataSummary";
-import getTypes from "lib/get/post-types";
 import getMonthData from "lib/get/month-data";
 import getMonthDataFiles from "lib/get/month-data-files";
 import getPosts from "lib/get/posts";
@@ -108,12 +107,7 @@ const Page = async (props) => {
 
 export async function generateStaticParams() {
 	try {
-		// Get post types to create type archives
-		const ingoredTypes = ["photos", "journals"];
-		let types = await getTypes(true);
-		types = types.filter((type) => !ingoredTypes.includes(type));
-
-		// Get year data folders to create year archives
+		// Only prebuild year archives. Type archives are generated on demand.
 		const monthFiles = getMonthDataFiles();
 		const years: string[] = [];
 		for (const file of monthFiles) {
@@ -122,19 +116,11 @@ export async function generateStaticParams() {
 				years.push(year);
 			}
 		}
-		types.push(...years);
 
-		// Create both post type and year paths
-		return types.map((t) => ({ typeOrYear: t }));
+		return years.map((year) => ({ typeOrYear: year }));
 	} catch (err) {
 		console.error("Error getting typeoryear static paths", err);
-		return [
-			{ typeOrYear: "notes" },
-			{ typeOrYear: "articles" },
-			{ typeOrYear: "photos" },
-			{ typeOrYear: "likes" },
-			{ typeOrYear: "replies" },
-		];
+		return [];
 	}
 }
 

--- a/app/(default)/[typeOrYear]/page/[page]/page.tsx
+++ b/app/(default)/[typeOrYear]/page/[page]/page.tsx
@@ -1,7 +1,5 @@
 import PostList from 'components/PostList'
 import getPosts from 'lib/get/posts'
-import getTypes from 'lib/get/post-types'
-import getPageCount from 'lib/get/page-count'
 
 interface PageParams {
   page: string
@@ -12,23 +10,6 @@ const Page = async props => {
   const params = await props.params;
   const posts = await getPosts({ query: params })
   return <PostList posts={posts} type='home' params={params} />
-}
-
-export async function generateStaticParams (): Promise<PageParams[]> {
-  const params: PageParams[] = []
-  const ingoredTypes = ['photos', 'journals']
-  // Get all types
-  let types = await getTypes(true)
-  types = types.filter(type => !ingoredTypes.includes(type))
-  for (const type of types) {
-    // Get post count for each post type
-    const pageCount = await getPageCount({ type })
-    for (let pageNumber = 1; pageNumber < pageCount; pageNumber++) {
-      params.push({ page: `${pageNumber}`, typeOrYear: type })
-    }
-  }
-
-  return params
 }
 
 export default Page

--- a/app/(default)/category/[category]/page.tsx
+++ b/app/(default)/category/[category]/page.tsx
@@ -28,11 +28,4 @@ const Page = async props => {
   )
 }
 
-export async function generateStaticParams () {
-  // Get all categories
-  const categories = await getCategories()
-
-  return categories.map(({ slug }) => ({ category: slug }))
-}
-
 export default Page

--- a/app/(default)/category/[category]/page/[page]/page.tsx
+++ b/app/(default)/category/[category]/page/[page]/page.tsx
@@ -1,7 +1,6 @@
 import PostList from 'components/PostList'
 import getPosts from 'lib/get/posts'
 import getCategories from 'lib/get/categories'
-import getPageCount from 'lib/get/page-count'
 import { notFound } from 'next/navigation'
 
 interface PageParams {
@@ -19,7 +18,7 @@ const Page = async props => {
   }
 
   const posts = await getPosts({
-    query: { category: category.name, type: 'all' },
+    query: { category: category.name, type: 'all', page: params.page },
   })
 
   return (
@@ -32,24 +31,6 @@ const Page = async props => {
       />
     </>
   )
-}
-
-export async function generateStaticParams (): Promise<PageParams[]> {
-  const categoryPages: PageParams[] = []
-
-  // Get all categories
-  const categories = await getCategories()
-
-  for (const category of categories) {
-    // Get post count for each category
-    const pageCount = await getPageCount({ category: category.name })
-
-    for (let pageNumber = 1; pageNumber < pageCount; pageNumber++) {
-      categoryPages.push({ page: `${pageNumber}`, category: category.slug })
-    }
-  }
-
-  return categoryPages
 }
 
 export default Page

--- a/app/(default)/page/[page]/page.tsx
+++ b/app/(default)/page/[page]/page.tsx
@@ -1,6 +1,5 @@
 import PostList from "components/PostList";
 import getPosts from "lib/get/posts";
-import getPageCount from "lib/get/page-count";
 
 export interface PageParams {
 	page: string;
@@ -18,21 +17,6 @@ const Home = async (props) => {
 		/>
 	);
 };
-
-// export const metadata = {
-//   title: 'Home', // TODO: Home page 2
-// }
-
-export async function generateStaticParams(): Promise<PageParams[]> {
-	// Count how many pages are needed
-	const pageCount = await getPageCount();
-	const pages: PageParams[] = [];
-	for (let pageNumber = 1; pageNumber < pageCount; pageNumber++) {
-		pages.push({ page: `${pageNumber}` });
-	}
-
-	return pages;
-}
 
 export { generateMetadata } from "lib/get/metadata";
 

--- a/app/(full-width)/photos/page/[page]/page.tsx
+++ b/app/(full-width)/photos/page/[page]/page.tsx
@@ -1,6 +1,4 @@
 import PostList from 'components/PostList'
-import getTypes from 'lib/get/post-types'
-import getPageCount from 'lib/get/page-count'
 import getPosts from 'lib/get/posts'
 
 const Page = async props => {
@@ -12,24 +10,6 @@ const Page = async props => {
   return (
     <PostList posts={posts} type='photos' title={`Photos`} params={params} />
   )
-}
-
-export async function generateStaticParams () {
-  const params: any[] = []
-  const ingoredTypes = ['photos', 'journals']
-  // Get all types
-  let types = await getTypes(true)
-  types = types.filter(type => !ingoredTypes.includes(type))
-  for (const type of types) {
-    // Get post count for each post type
-    const pageCount = await getPageCount({ type })
-    for (let pageNumber = 1; pageNumber < pageCount; pageNumber++) {
-      params.push({ page: `${pageNumber}`, typeOrYear: type })
-    }
-  }
-
-  // Return the paths, with a fallback to dynamically new / old categories
-  return params
 }
 
 export default Page

--- a/lib/get/normalize-search-query.ts
+++ b/lib/get/normalize-search-query.ts
@@ -1,0 +1,71 @@
+const TYPE_ALIASES: Record<string, string> = {
+  article: 'article',
+  articles: 'article',
+  audio: 'audio',
+  audios: 'audio',
+  bookmark: 'bookmark',
+  bookmarks: 'bookmark',
+  checkin: 'checkin',
+  checkins: 'checkin',
+  collection: 'collection',
+  collections: 'collection',
+  event: 'event',
+  events: 'event',
+  journal: 'journal',
+  journals: 'journal',
+  like: 'like',
+  likes: 'like',
+  listen: 'listen',
+  listens: 'listen',
+  note: 'note',
+  notes: 'note',
+  photo: 'photo',
+  photos: 'photo',
+  quotation: 'quotation',
+  quotations: 'quotation',
+  read: 'read',
+  reads: 'read',
+  reacji: 'reacji',
+  reacjis: 'reacji',
+  reply: 'reply',
+  replies: 'reply',
+  repost: 'repost',
+  reposts: 'repost',
+  rsvp: 'rsvp',
+  rsvps: 'rsvp',
+  video: 'video',
+  videos: 'video',
+  watch: 'watch',
+  watches: 'watch',
+}
+
+const isYear = (value: string) => /^\d{4}$/.test(value)
+
+const normalizeType = (value: string) => TYPE_ALIASES[value] || value
+
+const normalizeSearchQuery = (query: Record<string, unknown> = {}) => {
+  const normalizedQuery: Record<string, unknown> = { ...query }
+  const typeOrYear = normalizedQuery.typeOrYear
+
+  if (typeof typeOrYear === 'string') {
+    if (isYear(typeOrYear)) {
+      normalizedQuery.year = typeOrYear
+    } else {
+      normalizedQuery.type = normalizeType(typeOrYear)
+    }
+
+    delete normalizedQuery.typeOrYear
+  }
+
+  for (const key of Object.keys(normalizedQuery)) {
+    const value = normalizedQuery[key]
+
+    if (value === undefined || value === null || value === '') {
+      delete normalizedQuery[key]
+    }
+  }
+
+  return normalizedQuery
+}
+
+export default normalizeSearchQuery

--- a/lib/get/page-count.ts
+++ b/lib/get/page-count.ts
@@ -1,5 +1,8 @@
+import normalizeSearchQuery from 'lib/get/normalize-search-query'
+
 const getPageCount = async (query = {}, limit = 10): Promise<number> => {
   const url = process.env.NEXT_PUBLIC_API_URL + '/api/page-count'
+  const normalizedQuery = normalizeSearchQuery(query)
   let headers = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
@@ -13,7 +16,7 @@ const getPageCount = async (query = {}, limit = 10): Promise<number> => {
     const res = await fetch(url, {
       headers,
       method: 'POST',
-      body: JSON.stringify({ query, limit }),
+      body: JSON.stringify({ query: normalizedQuery, limit }),
       signal: controller.signal,
     })
 

--- a/lib/get/posts.js
+++ b/lib/get/posts.js
@@ -1,7 +1,14 @@
+import normalizeSearchQuery from 'lib/get/normalize-search-query'
+
 const getPosts = async (ctx) => {
+  let timeout
+
   try {
     const { query = {}, limit = 10, showAll = false } = ctx
     const token = ctx?.previewData?.token ?? null
+    const normalizedQuery = normalizeSearchQuery(query)
+    const controller = new AbortController()
+    timeout = setTimeout(() => controller.abort(), 15000)
 
     const url = process.env.NEXT_PUBLIC_API_URL + '/api/search'
     let headers = {
@@ -17,8 +24,8 @@ const getPosts = async (ctx) => {
     const res = await fetch(url, {
       headers,
       method: 'POST',
-      body: JSON.stringify({ query, limit, showAll }),
-      timeout: 15000,
+      body: JSON.stringify({ query: normalizedQuery, limit, showAll }),
+      signal: controller.signal,
       next: {
         revalidate: 60 * 30,
       },
@@ -29,6 +36,8 @@ const getPosts = async (ctx) => {
   } catch (err) {
     console.warn('[Error getting posts]', err)
     return []
+  } finally {
+    clearTimeout(timeout)
   }
 }
 


### PR DESCRIPTION
## Summary
- stop prebuilding the expensive paginated archive and category routes
- normalize archive search queries before hitting the backend APIs
- fix paginated category queries and restore ignoring of .planning

## Testing
- npm run build